### PR TITLE
Run build after installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test": "node --harmony-async-await test/plugin-test.js",
     "release": "./node_modules/release-it/bin/release.js --src.tagName='v%s' --github.release --npm.publish --non-interactive",
     "release-minor": "./node_modules/release-it/bin/release.js minor --src.tagName='v%s' --github.release --npm.publish --non-interactive",
-    "release-major": "./node_modules/release-it/bin/release.js major --src.tagName='v%s' --github.release --npm.publish --non-interactive"
+    "release-major": "./node_modules/release-it/bin/release.js major --src.tagName='v%s' --github.release --npm.publish --non-interactive",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "base64url": "^2.0.0",


### PR DESCRIPTION
We reference all those build output scripts in our readme so package should generate them automatically after installation from npm.