### PR TITLE
remove crypto from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "co": "^4.6.0",
     "co-request": "^1.0.0",
     "core-js": "^2.4.1",
-    "crypto": "0.0.3",
     "debug": "^3.0.0",
     "es6-promise": "^4.1.0",
     "eventemitter2": "^4.1.0",


### PR DESCRIPTION
Is now (since what Node.js version?) a built-in Node module so `crypto` package has been deprecated on npm.

As far as I can see we only [use it here](https://github.com/bigchaindb/ilp-plugin-bigchaindb/blob/master/src/lib/bigchaindb_ledger_plugin.js#L242) but the code is commented out anyway so this PR won't affect anything right now.